### PR TITLE
Add typing

### DIFF
--- a/tests/unit/test_units.py
+++ b/tests/unit/test_units.py
@@ -9,18 +9,20 @@ from pint import UnitRegistry
 def get_speed_multiple_args(
     distance: u(float, "meter"),
     time: u(float, "second"),
-    duration: u(float | None, "second") = None
+    duration: u(float | None, "second") = None,
 ) -> u(float, "meter/second"):
     if duration is None:
         return distance / time
     else:
         return distance / duration
 
+
 @units
 def get_speed_optional_args(
     distance: u(float, "meter"), time: u(float, "second") = 1
 ) -> u(float, "meter/second"):
     return distance / time
+
 
 @units
 def get_speed_ints(
@@ -88,7 +90,9 @@ class TestUnits(unittest.TestCase):
             1 * ureg.meter / ureg.second,
         )
         self.assertEqual(
-            get_speed_multiple_args(1 * ureg.meter, 1 * ureg.second, 1 * ureg.millisecond),
+            get_speed_multiple_args(
+                1 * ureg.meter, 1 * ureg.second, 1 * ureg.millisecond
+            ),
             1000 * ureg.meter / ureg.second,
         )
 
@@ -107,6 +111,7 @@ class TestUnits(unittest.TestCase):
             get_speed_optional_args(1 * ureg.meter, 1 * ureg.millisecond),
             1000 * ureg.meter / ureg.second,
         )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/test_units.py
+++ b/tests/unit/test_units.py
@@ -1,0 +1,52 @@
+import numpy as np
+import unittest
+from uniton.typing import u
+from uniton.converter import units
+from pint import UnitRegistry
+
+
+@units
+def get_speed_ints(
+    distance: u(int, "meter"), time: u(int, "second")
+) -> u(int, "meter/second"):
+    return distance / time
+
+
+@units
+def get_speed_floats(
+    distance: u(float, "meter"), time: u(float, "second")
+) -> u(float, "meter/second"):
+    return distance / time
+
+
+@units
+def get_speed_relative(
+    distance: u(float, "=A"), time: u(float, "=B")
+) -> u(float, "=A/B"):
+    return distance / time
+
+
+class TestTools(unittest.TestCase):
+    def test_relative(self):
+        self.assertEqual(get_speed_relative(1, 1), 1)
+        ureg = UnitRegistry()
+        self.assertEqual(
+            get_speed_relative(1 * ureg.angstrom, 1 * ureg.meter),
+            1 * ureg.angstrom / ureg.meter,
+        )
+
+    def test_ints(self):
+        self.assertEqual(get_speed_ints(1, 1), 1)
+        ureg = UnitRegistry()
+        self.assertEqual(
+            get_speed_ints(1 * ureg.meter, 1 * ureg.second),
+            1 * ureg.meter / ureg.second,
+        )
+        self.assertEqual(
+            get_speed_ints(1 * ureg.millimeter, 1 * ureg.second),
+            0.001 * ureg.meter / ureg.second,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_units.py
+++ b/tests/unit/test_units.py
@@ -1,4 +1,3 @@
-import numpy as np
 import unittest
 from uniton.typing import u
 from uniton.converter import units

--- a/tests/unit/test_units.py
+++ b/tests/unit/test_units.py
@@ -6,6 +6,23 @@ from pint import UnitRegistry
 
 
 @units
+def get_speed_multiple_args(
+    distance: u(float, "meter"),
+    time: u(float, "second"),
+    duration: u(float | None, "second") = None
+) -> u(float, "meter/second"):
+    if duration is None:
+        return distance / time
+    else:
+        return distance / duration
+
+@units
+def get_speed_optional_args(
+    distance: u(float, "meter"), time: u(float, "second") = 1
+) -> u(float, "meter/second"):
+    return distance / time
+
+@units
 def get_speed_ints(
     distance: u(int, "meter"), time: u(int, "second")
 ) -> u(int, "meter/second"):
@@ -26,7 +43,7 @@ def get_speed_relative(
     return distance / time
 
 
-class TestTools(unittest.TestCase):
+class TestUnits(unittest.TestCase):
     def test_relative(self):
         self.assertEqual(get_speed_relative(1, 1), 1)
         ureg = UnitRegistry()
@@ -43,10 +60,53 @@ class TestTools(unittest.TestCase):
             1 * ureg.meter / ureg.second,
         )
         self.assertEqual(
-            get_speed_ints(1 * ureg.millimeter, 1 * ureg.second),
+            get_speed_ints(1 * ureg.meter, 1 * ureg.millisecond),
+            1000 * ureg.meter / ureg.second,
+        )
+
+    def test_floats(self):
+        self.assertEqual(get_speed_floats(1.0, 1.0), 1.0)
+        ureg = UnitRegistry()
+        self.assertEqual(
+            get_speed_floats(1.0 * ureg.meter, 1.0 * ureg.second),
+            1.0 * ureg.meter / ureg.second,
+        )
+        self.assertEqual(
+            get_speed_floats(1.0 * ureg.millimeter, 1.0 * ureg.second),
             0.001 * ureg.meter / ureg.second,
         )
 
+    def test_multiple_args(self):
+        self.assertEqual(get_speed_multiple_args(1, 1), 1)
+        ureg = UnitRegistry()
+        self.assertEqual(
+            get_speed_multiple_args(1 * ureg.meter, 1 * ureg.second),
+            1 * ureg.meter / ureg.second,
+        )
+        self.assertEqual(
+            get_speed_multiple_args(1 * ureg.meter, 1 * ureg.second, 1 * ureg.second),
+            1 * ureg.meter / ureg.second,
+        )
+        self.assertEqual(
+            get_speed_multiple_args(1 * ureg.meter, 1 * ureg.second, 1 * ureg.millisecond),
+            1000 * ureg.meter / ureg.second,
+        )
+
+    def test_optional_args(self):
+        self.assertEqual(get_speed_optional_args(1), 1)
+        ureg = UnitRegistry()
+        self.assertEqual(
+            get_speed_optional_args(1 * ureg.meter),
+            1 * ureg.meter / ureg.second,
+        )
+        self.assertEqual(
+            get_speed_optional_args(1 * ureg.meter, 1 * ureg.second),
+            1 * ureg.meter / ureg.second,
+        )
+        self.assertEqual(
+            get_speed_optional_args(1 * ureg.meter, 1 * ureg.millisecond),
+            1000 * ureg.meter / ureg.second,
+        )
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/test_units.py
+++ b/tests/unit/test_units.py
@@ -5,6 +5,12 @@ from pint import UnitRegistry
 
 
 @units
+def get_speed_no_output_type(
+    distance: u(float, "meter"), time: u(float, "second")
+):
+    return distance / time
+
+@units
 def get_speed_multiple_args(
     distance: u(float, "meter"),
     time: u(float, "second"),
@@ -109,6 +115,16 @@ class TestUnits(unittest.TestCase):
         self.assertEqual(
             get_speed_optional_args(1 * ureg.meter, 1 * ureg.millisecond),
             1000 * ureg.meter / ureg.second,
+        )
+
+    def test_no_output_type(self):
+        self.assertEqual(get_speed_no_output_type(1, 1), 1)
+        ureg = UnitRegistry()
+        self.assertEqual(
+            get_speed_no_output_type(1 * ureg.meter, 1 * ureg.second), 1
+        )
+        self.assertEqual(
+            get_speed_no_output_type(1 * ureg.millimeter, 1 * ureg.second), 0.001
         )
 
 

--- a/tests/unit/test_units.py
+++ b/tests/unit/test_units.py
@@ -10,6 +10,7 @@ def get_speed_no_output_type(
 ):
     return distance / time
 
+
 @units
 def get_speed_multiple_args(
     distance: u(float, "meter"),

--- a/uniton/converter.py
+++ b/uniton/converter.py
@@ -2,11 +2,11 @@
 # Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
 # Distributed under the terms of "New BSD License", see the LICENSE file.
 
-from pint import Quantity, Unit
+from pint import Quantity
 import inspect
-import warnings
 from functools import wraps
 from typing import Annotated, get_type_hints
+from pint.registry_helpers import _apply_defaults, _parse_wrap_args, _to_units_container, _replace_units
 
 __author__ = "Sam Waseda"
 __copyright__ = (
@@ -21,19 +21,59 @@ __date__ = "Aug 21, 2021"
 
 
 def _get_ureg(args, kwargs):
-    """
-    Get the registry from the arguments.
-
-    Parameters
-    ----------
-    args : tuple
-    kwargs : dict
-
-    Returns
-    -------
-    pint.UnitRegistry
-    """
     for arg in args + tuple(kwargs.values()):
         if isinstance(arg, Quantity):
             return arg._REGISTRY
     return None
+
+
+def _get_args(sig):
+    args = []
+    for value in sig.parameters.values():
+        if hasattr(value.annotation, "__metadata__"):
+            args.append(value.annotation.__metadata__[0])
+        else:
+            args.append(None)
+    return args
+
+def _get_converter(sig):
+    args = _get_args(sig)
+    if any([arg is not None for arg in args]):
+        return _parse_wrap_args(args)
+    else:
+        return None
+
+
+def units(func):
+    """
+    Decorator to convert the output of a function to a Quantity object with the specified units.
+
+    Args:
+        func: function to be decorated
+
+    Returns:
+        decorated function
+    """
+    sig = inspect.signature(func)
+    converter = _get_converter(sig)
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        ureg = _get_ureg(args, kwargs)
+        if converter is None or ureg is None:
+            return func(*args, **kwargs)
+        args, kwargs = _apply_defaults(sig, args, kwargs)
+        args, kwargs, names = converter(ureg, sig, args, kwargs, strict=False)
+        try:
+            ret = _to_units_container(sig.return_annotation.__metadata__[0], ureg)
+            out_units = (
+                _replace_units(r, names) if is_ref else r
+                for (r, is_ref) in ret
+            )
+            output_units = ureg.Quantity(1, _replace_units(ret[0], names) if ret[1] else ret[0])
+        except AttributeError:
+            output_units = None
+        if output_units is None:
+            return func(*args, **kwargs)
+        else:
+            return output_units * func(*args, **kwargs)
+    return wrapper

--- a/uniton/converter.py
+++ b/uniton/converter.py
@@ -5,7 +5,6 @@
 from pint import Quantity
 import inspect
 from functools import wraps
-from typing import get_type_hints
 from pint.registry_helpers import _apply_defaults, _parse_wrap_args, _to_units_container, _replace_units
 
 __author__ = "Sam Waseda"

--- a/uniton/converter.py
+++ b/uniton/converter.py
@@ -71,9 +71,6 @@ def units(func):
         args, kwargs, names = converter(ureg, sig, args, kwargs, strict=False)
         try:
             ret = _to_units_container(sig.return_annotation.__metadata__[0], ureg)
-            out_units = (
-                _replace_units(r, names) if is_ref else r for (r, is_ref) in ret
-            )
             output_units = ureg.Quantity(
                 1, _replace_units(ret[0], names) if ret[1] else ret[0]
             )

--- a/uniton/converter.py
+++ b/uniton/converter.py
@@ -5,7 +5,7 @@
 from pint import Quantity
 import inspect
 from functools import wraps
-from typing import Annotated, get_type_hints
+from typing import get_type_hints
 from pint.registry_helpers import _apply_defaults, _parse_wrap_args, _to_units_container, _replace_units
 
 __author__ = "Sam Waseda"

--- a/uniton/converter.py
+++ b/uniton/converter.py
@@ -5,7 +5,12 @@
 from pint import Quantity
 import inspect
 from functools import wraps
-from pint.registry_helpers import _apply_defaults, _parse_wrap_args, _to_units_container, _replace_units
+from pint.registry_helpers import (
+    _apply_defaults,
+    _parse_wrap_args,
+    _to_units_container,
+    _replace_units,
+)
 
 __author__ = "Sam Waseda"
 __copyright__ = (
@@ -35,6 +40,7 @@ def _get_args(sig):
             args.append(None)
     return args
 
+
 def _get_converter(sig):
     args = _get_args(sig)
     if any([arg is not None for arg in args]):
@@ -55,6 +61,7 @@ def units(func):
     """
     sig = inspect.signature(func)
     converter = _get_converter(sig)
+
     @wraps(func)
     def wrapper(*args, **kwargs):
         ureg = _get_ureg(args, kwargs)
@@ -65,14 +72,16 @@ def units(func):
         try:
             ret = _to_units_container(sig.return_annotation.__metadata__[0], ureg)
             out_units = (
-                _replace_units(r, names) if is_ref else r
-                for (r, is_ref) in ret
+                _replace_units(r, names) if is_ref else r for (r, is_ref) in ret
             )
-            output_units = ureg.Quantity(1, _replace_units(ret[0], names) if ret[1] else ret[0])
+            output_units = ureg.Quantity(
+                1, _replace_units(ret[0], names) if ret[1] else ret[0]
+            )
         except AttributeError:
             output_units = None
         if output_units is None:
             return func(*args, **kwargs)
         else:
             return output_units * func(*args, **kwargs)
+
     return wrapper

--- a/uniton/converter.py
+++ b/uniton/converter.py
@@ -1,0 +1,39 @@
+# coding: utf-8
+# Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
+# Distributed under the terms of "New BSD License", see the LICENSE file.
+
+from pint import Quantity, Unit
+import inspect
+import warnings
+from functools import wraps
+from typing import Annotated, get_type_hints
+
+__author__ = "Sam Waseda"
+__copyright__ = (
+    "Copyright 2021, Max-Planck-Institut für Eisenforschung GmbH "
+    "- Computational Materials Design (CM) Department"
+)
+__version__ = "1.0"
+__maintainer__ = "Sam Waseda"
+__email__ = "waseda@mpie.de"
+__status__ = "development"
+__date__ = "Aug 21, 2021"
+
+
+def _get_ureg(args, kwargs):
+    """
+    Get the registry from the arguments.
+
+    Parameters
+    ----------
+    args : tuple
+    kwargs : dict
+
+    Returns
+    -------
+    pint.UnitRegistry
+    """
+    for arg in args + tuple(kwargs.values()):
+        if isinstance(arg, Quantity):
+            return arg._REGISTRY
+    return None

--- a/uniton/typing.py
+++ b/uniton/typing.py
@@ -2,8 +2,8 @@ from typing import Annotated, Any
 
 __author__ = "Sam Waseda"
 __copyright__ = (
-   "Copyright 2021, Max-Planck-Institut für Eisenforschung GmbH "
-   "- Computational Materials Design (CM) Department"
+    "Copyright 2021, Max-Planck-Institut für Eisenforschung GmbH "
+    "- Computational Materials Design (CM) Department"
 )
 __version__ = "1.0"
 __maintainer__ = "Sam Waseda"

--- a/uniton/typing.py
+++ b/uniton/typing.py
@@ -1,0 +1,16 @@
+from typing import Annotated, Any
+
+__author__ = "Sam Waseda"
+__copyright__ = (
+   "Copyright 2021, Max-Planck-Institut für Eisenforschung GmbH "
+   "- Computational Materials Design (CM) Department"
+)
+__version__ = "1.0"
+__maintainer__ = "Sam Waseda"
+__email__ = "waseda@mpie.de"
+__status__ = "development"
+__date__ = "Aug 21, 2021"
+
+
+def u(type_, /, units: str | None = None, otype: Any = None):
+    return Annotated[type_, units, otype]


### PR DESCRIPTION
Originally planned [here](https://github.com/pyiron/elaston/pull/52) but I decided to make it internally a bit less complicated.

```python
@units
def get_speed_onto(
    distance: u(float, "meter"), time: u(float, "second")
) -> u(float, "meter/second"):
    return distance / time
```

The functionality is the same as shown in the previous PRs. What happens internally is:

```python
print(u(float, "meter/second"))
```

Output: `typing.Annotated[float, 'meter/second', None]`

And it's up to the parser to figure out what to do with the additional information. The last item in the list is meant to be used for the ontology type