### PR TITLE
Allow multiple return

### DIFF
--- a/tests/unit/test_units.py
+++ b/tests/unit/test_units.py
@@ -2,13 +2,12 @@ import unittest
 from uniton.typing import u
 from uniton.converter import units
 from pint import UnitRegistry
-from typing import Tuple
 
 
 @units
 def get_speed_multiple_outputs(
     distance: u(float, "meter"), time: u(float, "second"), duration: u(float, "second")
-) -> Tuple[u(float, "meter/second"), u(float, "meter/second")]:
+) -> (u(float, "meter/second"), u(float, "meter/second")):
     return distance / time, distance / duration
 
 

--- a/tests/unit/test_units.py
+++ b/tests/unit/test_units.py
@@ -13,9 +13,7 @@ def get_speed_multiple_outputs(
 
 
 @units
-def get_speed_no_output_type(
-    distance: u(float, "meter"), time: u(float, "second")
-):
+def get_speed_no_output_type(distance: u(float, "meter"), time: u(float, "second")):
     return distance / time
 
 
@@ -129,9 +127,7 @@ class TestUnits(unittest.TestCase):
     def test_no_output_type(self):
         self.assertEqual(get_speed_no_output_type(1, 1), 1)
         ureg = UnitRegistry()
-        self.assertEqual(
-            get_speed_no_output_type(1 * ureg.meter, 1 * ureg.second), 1
-        )
+        self.assertEqual(get_speed_no_output_type(1 * ureg.meter, 1 * ureg.second), 1)
         self.assertEqual(
             get_speed_no_output_type(1 * ureg.millimeter, 1 * ureg.second), 0.001
         )
@@ -140,7 +136,9 @@ class TestUnits(unittest.TestCase):
         self.assertEqual(get_speed_multiple_outputs(1, 1, 1), (1, 1))
         ureg = UnitRegistry()
         self.assertEqual(
-            get_speed_multiple_outputs(1 * ureg.meter, 1 * ureg.second, 1 * ureg.second),
+            get_speed_multiple_outputs(
+                1 * ureg.meter, 1 * ureg.second, 1 * ureg.second
+            ),
             (1 * ureg.meter / ureg.second, 1 * ureg.meter / ureg.second),
         )
         self.assertEqual(

--- a/tests/unit/test_units.py
+++ b/tests/unit/test_units.py
@@ -2,6 +2,14 @@ import unittest
 from uniton.typing import u
 from uniton.converter import units
 from pint import UnitRegistry
+from typing import Tuple
+
+
+@units
+def get_speed_multiple_outputs(
+    distance: u(float, "meter"), time: u(float, "second"), duration: u(float, "second")
+) -> Tuple[u(float, "meter/second"), u(float, "meter/second")]:
+    return distance / time, distance / duration
 
 
 @units
@@ -126,6 +134,20 @@ class TestUnits(unittest.TestCase):
         )
         self.assertEqual(
             get_speed_no_output_type(1 * ureg.millimeter, 1 * ureg.second), 0.001
+        )
+
+    def test_multiple_outputs(self):
+        self.assertEqual(get_speed_multiple_outputs(1, 1, 1), (1, 1))
+        ureg = UnitRegistry()
+        self.assertEqual(
+            get_speed_multiple_outputs(1 * ureg.meter, 1 * ureg.second, 1 * ureg.second),
+            (1 * ureg.meter / ureg.second, 1 * ureg.meter / ureg.second),
+        )
+        self.assertEqual(
+            get_speed_multiple_outputs(
+                1 * ureg.meter, 1 * ureg.second, 1 * ureg.millisecond
+            ),
+            (1 * ureg.meter / ureg.second, 1000 * ureg.meter / ureg.second),
         )
 
 

--- a/uniton/converter.py
+++ b/uniton/converter.py
@@ -76,10 +76,10 @@ def units(func):
         args, kwargs = _apply_defaults(sig, args, kwargs)
         args, kwargs, names = converter(ureg, sig, args, kwargs, strict=False)
         try:
-            if get_origin(sig.return_annotation) is tuple:
+            if isinstance(sig.return_annotation, tuple):
                 output_units = [
                     _get_ret_units(ann, ureg, names)
-                    for ann in get_args(sig.return_annotation)
+                    for ann in sig.return_annotation
                 ]
             else:
                 output_units = _get_ret_units(sig.return_annotation, ureg, names)

--- a/uniton/converter.py
+++ b/uniton/converter.py
@@ -78,8 +78,7 @@ def units(func):
         try:
             if isinstance(sig.return_annotation, tuple):
                 output_units = [
-                    _get_ret_units(ann, ureg, names)
-                    for ann in sig.return_annotation
+                    _get_ret_units(ann, ureg, names) for ann in sig.return_annotation
                 ]
             else:
                 output_units = _get_ret_units(sig.return_annotation, ureg, names)

--- a/uniton/converter.py
+++ b/uniton/converter.py
@@ -11,7 +11,6 @@ from pint.registry_helpers import (
     _to_units_container,
     _replace_units,
 )
-from typing import get_origin, get_args
 
 __author__ = "Sam Waseda"
 __copyright__ = (


### PR DESCRIPTION
This should be an important feature for workflows.

Taken from the tests:

```python
@units
def get_speed_multiple_outputs(
    distance: u(float, "meter"), time: u(float, "second"), duration: u(float, "second")
) -> (u(float, "meter/second"), u(float, "meter/second")):
    return distance / time, distance / duration
```

The only problem might be that it gets fairly chaotic, but maybe that's something we have to live with...