### PR TITLE
Append type hinting to the class

### DIFF
--- a/tests/unit/test_dataclass.py
+++ b/tests/unit/test_dataclass.py
@@ -1,0 +1,45 @@
+import unittest
+from uniton.converter import append_types
+from typing import Annotated
+from dataclasses import dataclass
+
+
+@dataclass
+class Pizza:
+    size: Annotated[float, "centimeter"]
+    price: int = 30
+
+    @dataclass
+    class Topping:
+        sauce: str
+
+    def calculate_price(self, discount: float = 0) -> float:
+        return self.price * (1 - discount)
+
+    @property
+    def original_price(self):
+        return self.price
+
+
+class TestDataclass(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        append_types(Pizza)
+
+    def test_type(self):
+        self.assertEqual(Pizza.price, int)
+        self.assertEqual(Pizza.size, Annotated[float, "centimeter"])
+        self.assertEqual(Pizza.Topping.sauce, str)
+
+    def test_after_instantiation(self):
+        pizza = Pizza(20)
+        self.assertEqual(pizza.size, 20)
+        self.assertEqual(pizza.price, 30)
+        self.assertIsInstance(pizza, Pizza)
+        sauce = Pizza.Topping("tomato")
+        self.assertEqual(sauce.sauce, "tomato")
+        self.assertIsInstance(sauce, Pizza.Topping)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_dataclass.py
+++ b/tests/unit/test_dataclass.py
@@ -22,8 +22,7 @@ class Pizza:
 
 
 class TestDataclass(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
+    def setUp(self):
         append_types(Pizza)
 
     def test_type(self):

--- a/uniton/converter.py
+++ b/uniton/converter.py
@@ -123,7 +123,7 @@ def append_types(cls: type):
     >>> print(Pizza.size)
     >>> print(Pizza.price)
     >>> print(Pizza.Topping.sauce)
-    
+
     Output:
 
     <class '__main__.Pizza'>

--- a/uniton/converter.py
+++ b/uniton/converter.py
@@ -93,3 +93,20 @@ def units(func):
             return output_units * func(*args, **kwargs)
 
     return wrapper
+
+
+def append_types(cls: type):
+    """
+    Append type hints to the class attributes.
+
+    Args:
+        cls: class to be decorated
+    """
+    for key, value in cls.__dict__.items():
+        if isinstance(value, type):
+            append_types(getattr(cls, key))
+    try:
+        for key, value in cls.__annotations__.items():
+            setattr(cls, key, value)
+    except AttributeError:
+        pass

--- a/uniton/converter.py
+++ b/uniton/converter.py
@@ -101,6 +101,39 @@ def append_types(cls: type):
 
     Args:
         cls: class to be decorated
+
+    Comments:
+
+    >>> from dataclasses import dataclass
+    >>> from typing import Annotated
+    >>> from uniton.converter.append_types
+
+    >>> @dataclass
+    >>> class Pizza:
+    >>>     price: Annotated[float, "money"]
+    >>>     size: Annotated[float, "dimension"]
+
+    >>>     @dataclass
+    >>>     class Topping:
+    >>>         sauce: Annotated[str, "matter"]
+
+    >>> append_types(Pizza)
+    >>> print(Pizza)
+    >>> print(Pizza.Topping)
+    >>> print(Pizza.size)
+    >>> print(Pizza.price)
+    >>> print(Pizza.Topping.sauce)
+    
+    Output:
+
+    <class '__main__.Pizza'>
+    <class '__main__.Pizza.Topping'>
+    typing.Annotated[float, 'dimension']
+    typing.Annotated[float, 'money']
+    typing.Annotated[str, 'matter']
+
+    The main point is the type hints are appended to the class attributes. The
+    classes remain untouched.
     """
     for key, value in cls.__dict__.items():
         if isinstance(value, type):


### PR DESCRIPTION
Following [this discussion](https://github.com/pyiron/uniton/issues/6) I finally realized what I had in mind, even though I have to admit it might not work exactly in the way I wish it would.

For this class:

```python
from dataclasses import dataclass
from typing import Annotated

@dataclass
class Pizza:
    price: Annotated[float, "money"]
    size: Annotated[float, "dimension"]

    @dataclass
    class Topping:
        sauce: Annotated[str, "matter"]
```

I get the following behaviour:

```python
from uniton.converter.append_types

append_types(Pizza)

print(Pizza)
print(Pizza.Topping)
print(Pizza.size)
print(Pizza.price)
print(Pizza.Topping.sauce)
```

Output:

```python
<class '__main__.Pizza'>
<class '__main__.Pizza.Topping'>
typing.Annotated[float, 'dimension']
typing.Annotated[float, 'money']
typing.Annotated[str, 'matter']
```

The only one problem is that the default value is lost when there is one and it's accessed without instantiating the class, i.e.

```python
@dataclass
class Pizza:
    size: Annotated[float, "dimension"] = 10

print(Pizza.size)
append_types(Pizza)
print(Pizza.size)
```

Output:

```python
10
typing.Annotated[float, 'dimension']
```

But it doesn't really interfere with any functionality if it's instantiated. This being said, I would have loved to do it without overwriting the class, but I couldn't find any viable solution other than this one.