### PR TITLE
Make argument parsers more independent

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -12,9 +12,9 @@ In the realm of the workflow management systems, there are well defined inputs a
 from uniton.typing import u
 
 def my_function(
-    a: u(int, "meter", my_ontology_for_length),
-    b: u(int, "second", my_ontology_for_time)
-) -> u(int, "meter/second", my_ontology_for_speed):
+    a: u(int, units="meter"),
+    b: u(int, units="second")
+) -> u(int, units="meter/second", label="speed"):
     return a / b
 ```
 
@@ -31,9 +31,9 @@ from pint import UnitRegistry
 
 @units
 def my_function(
-    a: u(int, "meter", my_ontology_for_length),
-    b: u(int, "second", my_ontology_for_time)
-) -> u(int, "meter/second", my_ontology_for_speed):
+    a: u(int, units="meter"),
+    b: u(int, units="second")
+) -> u(int, units="meter/second", label="speed"):
     return a / b
 
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -47,8 +47,11 @@ Output: `1.0 meter / second`
 
 The interpreters check all types and, if necessary, convert them to the expected types **before** the function is executed, in order for all possible errors would be raised before the function execution. The interpreters convert the types in the way that the underlying function would receive the raw values.
 
-In case there are multiple outputs, the type hints are to be passed as a tuple (e.g. `(u(int, "meter", my_ontology_for_length), u(int, "second", my_ontology_for_time))`).
+In case there are multiple outputs, the type hints are to be passed as a tuple (e.g. `(u(int, "meter"), u(int, "second"))`).
 
 Interpreters can distinguish between annotated arguments and non-anotated arguments. If the argument is annotated, the interpreter will try to convert the argument to the expected type. If the argument is not annotated, the interpreter will pass the argument as is.
 
 Regardless of type hints are given or not, the interpreter acts only when the input values contain units and ontological types. If the input values do not contain units and ontological types, the interpreter will pass the input values to the function as is.
+
+For arguments beyond units, you can use the functions `parse_input_args` and `parse_output_args` to extract the variable information. `parse_input_args` parses the input variables and return a dictionary with the variable names as keys and the variable information as values. `parse_output_args` parses the output variables and return a dictionary with the variable information as values if there is one output variable, or a list of dictionaries if it is a tuple.
+

--- a/tests/unit/test_parsers.py
+++ b/tests/unit/test_parsers.py
@@ -4,12 +4,17 @@ from uniton.converter import parse_input_args, parse_output_args
 
 
 class TestUnits(unittest.TestCase):
-    def test_use_list(self):
+    def test_content(self):
         def get_speed(
             distance: u(float, "meter", use_list=True),
             time: u(float, "second", use_list=True),
         ) -> u(float, "meter/second", use_list=True):
             return distance / time
+        input_args = parse_input_args(get_speed)
+        for key in ["distance", "time"]:
+            self.assertTrue(key in input_args)
+        for key in ["units", "uri", "shape"]:
+            self.assertTrue(key in input_args["distance"])
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_parsers.py
+++ b/tests/unit/test_parsers.py
@@ -1,0 +1,16 @@
+import unittest
+from uniton.typing import u
+from uniton.converter import parse_input_args, parse_output_args
+
+
+class TestUnits(unittest.TestCase):
+    def test_use_list(self):
+        def get_speed(
+            distance: u(float, "meter", use_list=True),
+            time: u(float, "second", use_list=True),
+        ) -> u(float, "meter/second", use_list=True):
+            return distance / time
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Now `parse_input_args` and `parse_output_args` can be used only with the function argument, i.e. you can call `parse_input_args(my_function)` and it returns the input args in a dictionary.