### PR TITLE
Separate metadata parser

### DIFF
--- a/tests/unit/test_dataclass.py
+++ b/tests/unit/test_dataclass.py
@@ -1,5 +1,6 @@
 import unittest
 from uniton.converter import append_types, parse_metadata
+from uniton.typing import u
 from typing import Annotated
 from dataclasses import dataclass
 
@@ -21,9 +22,15 @@ class Pizza:
         return self.price
 
 
+@dataclass
+class Output:
+    total_energy: u(float, units="eV", label="TotalEnergy", associate_to_sample=True)
+
+
 class TestDataclass(unittest.TestCase):
     def setUp(self):
         append_types(Pizza)
+        append_types(Output)
 
     def test_type(self):
         self.assertEqual(Pizza.price, int)
@@ -38,6 +45,19 @@ class TestDataclass(unittest.TestCase):
         sauce = Pizza.Topping("tomato")
         self.assertEqual(sauce.sauce, "tomato")
         self.assertIsInstance(sauce, Pizza.Topping)
+
+    def test_parse_metadata(self):
+        metadata = parse_metadata(Output.total_energy)
+        self.assertEqual(
+            metadata,
+            {
+                "units": "eV",
+                "label": "TotalEnergy",
+                "associate_to_sample": True,
+                "shape": None,
+                "uri": None,
+            },
+        )
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_dataclass.py
+++ b/tests/unit/test_dataclass.py
@@ -1,5 +1,5 @@
 import unittest
-from uniton.converter import append_types
+from uniton.converter import append_types, parse_metadata
 from typing import Annotated
 from dataclasses import dataclass
 

--- a/uniton/converter.py
+++ b/uniton/converter.py
@@ -32,27 +32,27 @@ def _get_ureg(args, kwargs):
     return None
 
 
-def parse_metadata(metadata):
+def parse_metadata(value):
     """
     Parse the metadata of a Quantity object.
 
     Args:
-        metadata: metadata of a Quantity object
+        value: Quantity object
 
     Returns:
         dictionary of the metadata. Available keys are `units`, `otype`,
         `shape`, and `dtype`. See `uniton.typing.u` for more details.
     """
     # When there is only one metadata `use_list=False` must have been used
-    if len(metadata) == 1:
-        return literal_eval(metadata[0])
+    if len(value.__metadata__) == 1:
+        return literal_eval(value.__metadata__[0])
     else:
-        return dict(zip(["units", "label", "uri", "shape"], metadata))
+        return dict(zip(["units", "label", "uri", "shape"], value.__metadata__))
 
 
 def _meta_to_dict(value):
     if hasattr(value, "__metadata__"):
-        result = parse_metadata(value.__metadata__)
+        result = parse_metadata(value)
         result["dtype"] = value.__args__[0]
         return result
     else:

--- a/uniton/converter.py
+++ b/uniton/converter.py
@@ -32,13 +32,27 @@ def _get_ureg(args, kwargs):
     return None
 
 
+def parse_metadata(metadata):
+    """
+    Parse the metadata of a Quantity object.
+
+    Args:
+        metadata: metadata of a Quantity object
+
+    Returns:
+        dictionary of the metadata. Available keys are `units`, `otype`,
+        `shape`, and `dtype`. See `uniton.typing.u` for more details.
+    """
+    # When there is only one metadata `use_list=False` must have been used
+    if len(metadata) == 1:
+        return literal_eval(metadata[0])
+    else:
+        return dict(zip(["units", "label", "uri", "shape"], metadata))
+
+
 def _meta_to_dict(value):
     if hasattr(value, "__metadata__"):
-        # When there is only one metadata `use_list=False` must have been used
-        if len(value.__metadata__) == 1:
-            result = literal_eval(value.__metadata__[0])
-        else:
-            result = dict(zip(["units", "label", "uri", "shape"], value.__metadata__))
+        result = parse_metadata(value.__metadata__)
         result["dtype"] = value.__args__[0]
         return result
     else:


### PR DESCRIPTION
Following the developer meeting, it looks like we will need the type hinting from data classes, and therefore the parser for the metadata has to be separated. In particular, we will be able to do something like:

```python
from uniton.typing import u
from uniton.converter import append_types


class Output:
    total_energy: u(float, units="eV", label="TotalEnergy", associate_to_sample=True)

append_types(Output)
```

And `Output.total_energy` should return the dict of the items given above.